### PR TITLE
Add simple no-HPO benchmark across all standard datasets and models

### DIFF
--- a/configs/benchmark/simple_all_datasets_all_models_no_hpo.yaml
+++ b/configs/benchmark/simple_all_datasets_all_models_no_hpo.yaml
@@ -1,0 +1,50 @@
+benchmark_id: simple_all_datasets_all_models_no_hpo
+task_type: right_censored_survival
+split_strategy: fixed_split
+seeds: [11]
+primary_metric: uno_c
+secondary_metrics:
+  - harrell_c
+  - ibs
+  - td_auc
+autogluon:
+  enabled: false
+  presets: medium
+  time_limit_seconds: null
+  hyperparameter_tune_kwargs: null
+  num_bag_folds: 0
+  num_stack_levels: 0
+  refit_full: false
+time_horizons_quantiles: [0.25, 0.5, 0.75]
+datasets:
+  - support
+  - metabric
+  - aids
+  - gbsg2
+  - flchain
+  - whas500
+methods:
+  - coxph
+  - coxnet
+  - weibull_aft
+  - lognormal_aft
+  - loglogistic_aft
+  - aalen_additive
+  - fast_survival_svm
+  - rsf
+  - extra_survival_trees
+  - gradient_boosting_survival
+  - componentwise_gradient_boosting
+  - xgboost_cox
+  - xgboost_aft
+  - catboost_cox
+  - catboost_survival_aft
+  - deepsurv
+  - deepsurv_moco
+  - logistic_hazard
+  - pmf
+  - mtlr
+  - deephit_single
+  - pchazard
+  - cox_time
+notes: Simple no-HPO benchmark across all standard datasets and all registered manuscript models.


### PR DESCRIPTION
### Motivation
- Provide a lightweight, quick-to-run benchmark that executes all registered manuscript models on all standard built-in datasets without any hyperparameter optimization.
- Enable simple fixed-split experiments for smoke and coverage testing while keeping AutoGluon, bagging, stacking, and HPO disabled.

### Description
- Add `configs/benchmark/simple_all_datasets_all_models_no_hpo.yaml` which defines a `fixed_split` benchmark covering datasets `support`, `metabric`, `aids`, `gbsg2`, `flchain`, and `whas500`.
- Disable AutoGluon and tuning by setting `autogluon.enabled: false`, `hyperparameter_tune_kwargs: null`, `num_bag_folds: 0`, and `num_stack_levels: 0`.
- Include the full manuscript/default model roster (e.g. `coxph`, `coxnet`, `rsf`, `deepsurv`, `xgboost_cox`, `catboost_cox`, `deepsurv_moco`, etc.) and set `primary_metric: uno_c` with several `secondary_metrics`.
- Provide `time_horizons_quantiles` and a `notes` field describing the no-HPO intent.

### Testing
- Ran `python -m survarena.run_benchmark --benchmark-config configs/benchmark/simple_all_datasets_all_models_no_hpo.yaml --dry-run`, which completed successfully.
- Ran `python -m survarena.run_benchmark --benchmark-config configs/benchmark/simple_all_datasets_all_models_no_hpo.yaml --dataset whas500 --method coxph`, which completed successfully and saved outputs to `results/summary/exp_...`.
- Executed the full config (no-HPO, all datasets/all models) which was started in this environment and produced an `experiment_manifest.json` under `results/summary/` indicating the run was launched (the full run is long-running and may take substantial time to finish).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea58dd7208832f9e0ff286745967fe)