### PR TITLE
Add concise experiment navigator artifacts for benchmark outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ models, per-model test metrics, and the foundation-model catalog.
 Benchmark runs write timestamped experiment folders under `results/summary/`.
 Each experiment can include:
 
+- `README.md` and `experiment_navigator.json` as concise entry points
 - fold results
 - seed summaries
 - overall summaries

--- a/survarena/api/compare.py
+++ b/survarena/api/compare.py
@@ -11,6 +11,7 @@ from survarena.data.user_dataset import load_user_dataset
 from survarena.logging.export import (
     create_experiment_dir,
     export_dataset_curation_table,
+    export_experiment_navigator,
     export_fold_results,
     export_leaderboard,
     export_manuscript_comparison,
@@ -285,6 +286,14 @@ def compare_survival_models(
         output_dir=resolved_output_dir,
     )
     export_run_ledger(repo_root, run_records, benchmark_id=resolved_benchmark_id, output_dir=resolved_output_dir)
+    export_experiment_navigator(
+        resolved_output_dir,
+        benchmark_id=resolved_benchmark_id,
+        primary_metric=primary_metric,
+        split_count=len(splits),
+        method_count=len(method_ids),
+        leaderboard=leaderboard,
+    )
     return {
         **summary,
         "output_dir": str(resolved_output_dir),

--- a/survarena/logging/export.py
+++ b/survarena/logging/export.py
@@ -285,3 +285,73 @@ def export_run_ledger(
             "record_sections": ["schema_version", "manifest", "metrics", "backend_metadata", "failure"],
         },
     )
+
+
+def export_experiment_navigator(
+    output_dir: Path,
+    *,
+    benchmark_id: str,
+    primary_metric: str,
+    split_count: int,
+    method_count: int,
+    leaderboard: pd.DataFrame,
+) -> None:
+    top_runs = leaderboard.sort_values(by=[primary_metric], ascending=metric_direction(primary_metric) == "minimize").head(5)
+    top_records = top_runs.to_dict(orient="records")
+    core_files = [
+        f"{benchmark_id}_leaderboard.csv",
+        f"{benchmark_id}_overall_summary.json",
+        f"{benchmark_id}_manuscript_summary.json",
+        f"{benchmark_id}_dataset_curation.csv",
+        "experiment_manifest.json",
+    ]
+    detailed_files = [
+        f"{benchmark_id}_fold_results.csv",
+        f"{benchmark_id}_seed_summary.csv",
+        f"{benchmark_id}_leaderboard.json",
+        f"{benchmark_id}_rank_summary.csv",
+        f"{benchmark_id}_pairwise_win_rate.csv",
+        f"{benchmark_id}_elo_ratings.csv",
+        f"{benchmark_id}_bootstrap_ci.csv",
+        f"{benchmark_id}_failure_summary.csv",
+        f"{benchmark_id}_missing_metric_summary.csv",
+        f"{benchmark_id}_run_records.jsonl.gz",
+        f"{benchmark_id}_run_records_index.json",
+    ]
+    write_json(
+        output_dir / "experiment_navigator.json",
+        {
+            "benchmark_id": benchmark_id,
+            "primary_metric": primary_metric,
+            "split_count": int(split_count),
+            "method_count": int(method_count),
+            "core_files": core_files,
+            "detailed_files": detailed_files,
+            "top_runs": top_records,
+        },
+    )
+    lines = [
+        "# Experiment Navigator",
+        "",
+        f"- benchmark_id: `{benchmark_id}`",
+        f"- primary_metric: `{primary_metric}`",
+        f"- split_count: `{int(split_count)}`",
+        f"- method_count: `{int(method_count)}`",
+        "",
+        "## Start here (concise)",
+        *(f"- `{name}`" for name in core_files),
+        "",
+        "## Detailed artifacts",
+        *(f"- `{name}`" for name in detailed_files),
+        "",
+        "## Top runs",
+    ]
+    if top_records:
+        for idx, record in enumerate(top_records, start=1):
+            method_id = record.get("method_id", "unknown")
+            dataset_id = record.get("dataset_id", "unknown")
+            metric_value = record.get(primary_metric)
+            lines.append(f"{idx}. `{dataset_id}/{method_id}` {primary_metric}={metric_value}")
+    else:
+        lines.append("- No leaderboard rows available.")
+    (output_dir / "README.md").write_text("\n".join(lines) + "\n", encoding="utf-8")

--- a/tests/test_compare_api.py
+++ b/tests/test_compare_api.py
@@ -89,3 +89,5 @@ def test_compare_survival_models_writes_benchmark_style_outputs(tmp_path: Path, 
     assert (output_dir / "user_compare_fixed_dataset_curation.csv").exists()
     assert (output_dir / "user_compare_fixed_manuscript_summary.json").exists()
     assert (output_dir / "user_compare_fixed_run_records.jsonl.gz").exists()
+    assert (output_dir / "experiment_navigator.json").exists()
+    assert (output_dir / "README.md").exists()


### PR DESCRIPTION
### Motivation
- Benchmark experiment folders can contain many CSV/JSON artifacts which are hard to scan quickly, so a minimal entry-point is needed to help users locate key outputs and top runs. 

### Description
- Add `export_experiment_navigator` in `survarena/logging/export.py` to write `experiment_navigator.json` (structured list of core/detailed files and top-5 leaderboard rows) and a human-friendly `README.md` with a quick navigation guide. 
- Wire the navigator into the compare pipeline so `compare_survival_models(...)` calls `export_experiment_navigator(...)` after existing exports, producing the navigator artifacts in each experiment directory. 
- Update `tests/test_compare_api.py` to assert presence of `experiment_navigator.json` and `README.md` in the benchmark output. 
- Update `README.md` documentation to mention the new concise entry-point files for benchmark runs. 

### Testing
- Ran the updated benchmark output test: `pytest -q tests/test_compare_api.py` which executed the modified test but test collection failed due to a missing test dependency (`ModuleNotFoundError: No module named 'numpy'`).
- The change is covered by the modified test which now checks that `experiment_navigator.json` and `README.md` are created when `compare_survival_models` runs, but full test execution requires installing `numpy` into the test environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea782879e8832fbba8e27b87449594)