### PR TITLE
Add dataset-by-dataset manuscript run script and documentation

### DIFF
--- a/docs/benchmarking_workflow.md
+++ b/docs/benchmarking_workflow.md
@@ -69,3 +69,33 @@ Core artifacts include:
 - experiment manifests with config and environment metadata
 
 For the full protocol and artifact contract, see [`protocol.md`](protocol.md).
+
+## Dataset-by-Dataset, Model-by-Model Manuscript Runs
+
+When manuscript-grade runs are too expensive to execute as one monolithic job,
+run each dataset/method pair independently with resume support:
+
+```bash
+scripts/run_manuscript_by_dataset_model.sh
+```
+
+Defaults:
+
+- config: `configs/benchmark/manuscript_v1.yaml`
+- output root: `results/manuscript_dataset_model`
+- retries per run: `1`
+
+Useful overrides:
+
+```bash
+MAX_RETRIES=2 LIMIT_SEEDS=2 OUTPUT_ROOT=results/manuscript_partial \
+  scripts/run_manuscript_by_dataset_model.sh
+```
+
+The script writes one output directory per dataset and method plus:
+
+- per-run logs in `results/.../<dataset>/<method>.log`
+- aggregate status table in `results/.../run_status.csv`
+
+This pattern keeps long-running methods from blocking faster methods and makes
+retry/resume straightforward without re-running completed pairs.

--- a/scripts/run_manuscript_by_dataset_model.sh
+++ b/scripts/run_manuscript_by_dataset_model.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PYTHON_BIN="${PYTHON_BIN:-python}"
+BENCHMARK_CONFIG="${BENCHMARK_CONFIG:-configs/benchmark/manuscript_v1.yaml}"
+OUTPUT_ROOT="${OUTPUT_ROOT:-results/manuscript_dataset_model}"
+MAX_RETRIES="${MAX_RETRIES:-1}"
+LIMIT_SEEDS="${LIMIT_SEEDS:-}"
+EXTRA_ARGS="${EXTRA_ARGS:-}"
+
+if [[ ! -f "$BENCHMARK_CONFIG" ]]; then
+  echo "[error] Benchmark config not found: $BENCHMARK_CONFIG" >&2
+  exit 1
+fi
+
+mkdir -p "$OUTPUT_ROOT"
+
+readarray -t DATASETS < <("$PYTHON_BIN" - <<'PY' "$BENCHMARK_CONFIG"
+from pathlib import Path
+import sys
+import yaml
+
+cfg = yaml.safe_load(Path(sys.argv[1]).read_text(encoding="utf-8"))
+for item in cfg.get("datasets", []):
+    print(item)
+PY
+)
+
+readarray -t METHODS < <("$PYTHON_BIN" - <<'PY' "$BENCHMARK_CONFIG"
+from pathlib import Path
+import sys
+import yaml
+
+cfg = yaml.safe_load(Path(sys.argv[1]).read_text(encoding="utf-8"))
+for item in cfg.get("methods", []):
+    print(item)
+PY
+)
+
+if [[ "${#DATASETS[@]}" -eq 0 ]]; then
+  echo "[error] No datasets found in $BENCHMARK_CONFIG" >&2
+  exit 1
+fi
+
+if [[ "${#METHODS[@]}" -eq 0 ]]; then
+  echo "[error] No methods found in $BENCHMARK_CONFIG" >&2
+  exit 1
+fi
+
+printf '[plan] datasets=%s methods=%s config=%s\n' "${#DATASETS[@]}" "${#METHODS[@]}" "$BENCHMARK_CONFIG"
+
+for dataset in "${DATASETS[@]}"; do
+  dataset_output_dir="$OUTPUT_ROOT/$dataset"
+  mkdir -p "$dataset_output_dir"
+
+  for method in "${METHODS[@]}"; do
+    run_tag="${dataset}__${method}"
+    run_output_dir="$dataset_output_dir/$method"
+    log_path="$dataset_output_dir/${method}.log"
+
+    echo "[run] $run_tag"
+    start_epoch="$(date +%s)"
+
+    set +e
+    "$PYTHON_BIN" -m survarena.run_benchmark \
+      --config "$BENCHMARK_CONFIG" \
+      --dataset "$dataset" \
+      --method "$method" \
+      --output-dir "$run_output_dir" \
+      --resume \
+      --max-retries "$MAX_RETRIES" \
+      ${LIMIT_SEEDS:+--limit-seeds "$LIMIT_SEEDS"} \
+      $EXTRA_ARGS \
+      > "$log_path" 2>&1
+    status=$?
+    set -e
+
+    end_epoch="$(date +%s)"
+    elapsed="$((end_epoch - start_epoch))"
+
+    if [[ "$status" -eq 0 ]]; then
+      echo "[ok] $run_tag elapsed=${elapsed}s log=$log_path"
+    else
+      echo "[fail] $run_tag elapsed=${elapsed}s exit_code=$status log=$log_path" >&2
+    fi
+
+    printf '%s,%s,%s,%s,%s\n' \
+      "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+      "$dataset" \
+      "$method" \
+      "$status" \
+      "$elapsed" \
+      >> "$OUTPUT_ROOT/run_status.csv"
+  done
+done
+
+echo "[done] matrix run complete. status table: $OUTPUT_ROOT/run_status.csv"


### PR DESCRIPTION
### Motivation

- Provide a way to run manuscript-grade benchmarks per dataset/method pair to avoid monolithic long-running jobs and enable resume/retry semantics.
- Make it easy to run and monitor long experiments independently so faster methods do not get blocked by slower ones.

### Description

- Add `scripts/run_manuscript_by_dataset_model.sh` which reads `datasets` and `methods` from a benchmark YAML, iterates dataset/method pairs, and invokes `python -m survarena.run_benchmark` per pair with `--resume` and configurable `--max-retries` and `--limit-seeds` flags.
- Script validates the benchmark config, creates per-dataset output directories, writes per-run logs to `results/.../<dataset>/<method>.log`, and appends run entries to `results/.../run_status.csv` with timestamp, dataset, method, exit status, and elapsed time.
- Update `docs/benchmarking_workflow.md` with a new "Dataset-by-Dataset, Model-by-Model Manuscript Runs" section that documents the script, its defaults (`configs/benchmark/manuscript_v1.yaml`, `results/manuscript_dataset_model`, `MAX_RETRIES=1`), and examples for overriding with environment variables such as `MAX_RETRIES`, `LIMIT_SEEDS`, and `OUTPUT_ROOT`.

### Testing

- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fd862ca8c832fbd5d354c57f9e336)