### PR TITLE
Research: RSBS loss and censoring-aware dynamic concordance

### DIFF
--- a/docs/research_rsbs_stage2.md
+++ b/docs/research_rsbs_stage2.md
@@ -1,0 +1,49 @@
+# Stage 2 research findings: beyond Cox loss
+
+This exploratory study tested KMD, censoring-aware concordance estimands, matched PH/non-PH architectures, and a proper reference-scaled intensity objective.
+
+## Main findings
+
+- Under linear PH truth, CoxPH remained best.
+- Under nonlinear PH truth, nonlinear PH models closed nearly all of the gap; time variation was unnecessary.
+- Under crossing hazards, relaxing PH reduced known-truth survival ISE from about 0.0166 for CoxPH and 0.0126 for nonlinear PH to about 0.0058 for a time-varying piecewise hazard.
+- The implemented KMD V/U training penalties were around `1e-6` and did not materially change optimization. KMD is better retained as a held-out residual specification test until its normalization and covariance estimation are redesigned.
+- The measurable objective change came from a proper reference-scaled quadratic Bregman component, but its gain over matched likelihood was small and heterogeneous.
+- Across nine public datasets, no method was uniformly best. Random survival forests, CoxPH, flexible likelihood, and RSBS each led on different datasets.
+
+## Concordance taxonomy
+
+Harrell and Uno concordance evaluate a static risk ordering. Antolini concordance evaluates subject-specific survival curves at the earlier event time and therefore permits rankings to change over time. A time-dependent Uno estimator adds marginal IPCW to this dynamic comparison. If censoring is independent only conditional on covariates, pairwise conditional censoring weights and cross-fitting are needed.
+
+A calibration-deformation experiment raised oracle survival curves to powers from 0.5 to 2.0. Harrell, Uno, Antolini, and dynamic Uno concordance stayed essentially unchanged, while integrated Brier score and known-truth error were minimized only at the undeformed oracle. Concordance is therefore a discrimination estimand, not a measure of probabilistic correctness.
+
+## Revised method
+
+For candidate intensity `q`, fixed positive reference intensity `a`, exposure `E`, and event count `D`, use the beta-Bregman score
+
+```text
+L_beta,a = sum_k E_k a_k (q_k/a_k)^beta / beta
+                 - D_k (q_k/a_k)^(beta-1)/(beta-1).
+```
+
+The beta=1 limit is the log-intensity score. Beta=2 gives `E q^2/(2a) - D q/a`. The proposed training objective is
+
+```text
+L_RSBS = L_log + eta L_beta,a, eta >= 0.
+```
+
+Its population excess risk is an at-risk weighted Bregman divergence between the true and candidate intensities. A nonnegative mixture with the strictly proper log score remains strictly proper on identifiable follow-up support. The reference must be estimated from training data or by cross-fitting and detached from model gradients.
+
+## KMD diagnostic
+
+For moment residuals `xi_i`, use the off-diagonal statistic
+
+```text
+(||sum_i xi_i||^2 - sum_i ||xi_i||^2) / [2 n (n-1)].
+```
+
+It removes the V-statistic self-noise term and may be negative in finite samples. Build critics and evaluate moments on separate folds, then use a wild multiplier bootstrap for a held-out goodness-of-fit test.
+
+## Limitations
+
+The public datasets are mostly small tabular benchmarks, five split seeds give exploratory rather than publication-grade intervals, and some IPCW scores were not estimable beyond censoring support. The study supports a confirmatory protocol, not a universal superiority claim.

--- a/docs/rsbs_confirmatory_protocol.md
+++ b/docs/rsbs_confirmatory_protocol.md
@@ -1,0 +1,76 @@
+# RSBS confirmatory benchmark protocol
+
+## Scientific claim
+
+The exploratory work does **not** support replacing likelihood with KMD. The confirmatory hypothesis is narrower:
+
+> In settings with adequately supported time-varying effects, a matched flexible intensity model trained with validation-selected Reference-Scaled Bregman Survival (RSBS) improves proper distributional scores relative to the same architecture trained by right-censored log score alone, without material loss under proportional-hazards truth.
+
+## Objective
+
+For positive candidate interval hazards `q`, exposures `E`, events `D`, and a fixed training-only reference hazard `a`, use
+
+```text
+L_RSBS = L_log + eta L_beta,a, eta >= 0
+```
+
+with
+
+```text
+L_beta,a = sum_k E_k a_k (q_k/a_k)^beta / beta
+                 - D_k (q_k/a_k)^(beta-1)/(beta-1).
+```
+
+The beta=1 limit is the log-intensity score; beta=2 gives `E q^2/(2a) - D q/a`. Estimate `a` inside training folds or by cross-fitting and detach it from gradients.
+
+## Design
+
+- Five outer folds repeated five times.
+- Shared outer and inner splits for every method.
+- Preprocessing fitted only inside each outer fold.
+- Equal hyperparameter-trial and runtime budgets.
+- Preserve failed trials and runtime records.
+- Tune architecture, optimization, time bins, `beta`, `eta`, and the reference model only on inner folds.
+
+## Comparators
+
+CoxPH; penalized Cox; DeepCox; Cox-Time; discrete hazard; PC-Hazard; random survival forest; gradient boosting; matched low-rank PEXP-NLL; matched RSBS.
+
+## Metrics
+
+Primary: right-censored log score and integrated Brier score over predeclared supported follow-up.
+
+Secondary: calibration intercept/slope, RMST error, Harrell C, Uno C, Antolini C, time-dependent Uno C, cumulative/dynamic AUC, and decision-curve net benefit.
+
+Concordance metrics are discrimination estimands and must not be interpreted as calibration metrics.
+
+## Censoring
+
+- Estimate marginal or conditional censoring distributions using training folds only.
+- Cross-fit conditional censoring weights.
+- Report weight distributions, effective sample size, truncation horizon, and positivity violations.
+- Do not score beyond supported follow-up.
+
+## PH characterization
+
+Report global Schoenfeld tests, multiplicity-adjusted feature tests, estimated time-varying coefficients, event support by time interval, and performance differences between matched nonlinear-PH and time-varying architectures. Do not use one PH-test p-value as an automatic model-selection rule.
+
+## Simulations
+
+Vary sample size, event fraction, censoring fraction, covariate dimension, nonlinear strength, reversal amplitude, reversal time, delayed effects, cure fractions, multimodality, and censoring dependence. Include linear PH truth as a negative control.
+
+## Uncertainty
+
+- Paired outer-fold contrasts.
+- Dataset-clustered bootstrap for aggregate claims.
+- 95% percentile and BCa intervals.
+- Holm adjustment across confirmatory secondary endpoints.
+- Report effect sizes and failure rates, not winner counts alone.
+
+## KMD role
+
+Use the off-diagonal KMD U-statistic as a held-out specification diagnostic. Build critics on separate folds and calibrate rejection thresholds with a wild multiplier bootstrap. Do not treat finite-sample negative U-statistics as numerical errors.
+
+## Decision rule
+
+No method is declared superior unless the pre-specified primary paired interval excludes zero and the gain is not driven by unsupported follow-up, failed competitors, unequal tuning budgets, or a single dataset.

--- a/research/rsbs_stage2/README.md
+++ b/research/rsbs_stage2/README.md
@@ -1,0 +1,43 @@
+# RSBS Stage 2 research track
+
+This directory records an exploratory survival-modeling study that began with Kernel Martingale Discrepancy (KMD) and converged on a narrower, better-supported direction:
+
+> flexible event-intensity modeling + a strictly proper reference-scaled score + held-out martingale specification tests.
+
+## Current conclusion
+
+- The largest gains under crossing hazards came from relaxing the proportional-hazards architecture.
+- The implemented KMD V/U penalties were around `1e-6` and did not materially affect training.
+- A likelihood-anchored **Reference-Scaled Bregman Survival (RSBS)** loss is the next testable objective.
+- KMD is retained as a held-out specification diagnostic until covariance normalization and cross-fitting are implemented.
+- Time-dependent Uno C should replace the ambiguous label `IPCW-Antolini`; it corrects Antolini's censoring bias but does not measure calibration.
+
+## Files in this branch
+
+- `survarena/methods/deep/rsbs_loss.py`: architecture-agnostic PyTorch loss.
+- `survarena/evaluation/concordance_time_dependent.py`: transparent reference implementations of Harrell, Antolini, time-dependent Uno, and conditional pairwise IPCW concordance.
+- `tests/test_rsbs_research.py`: mathematical and numerical checks.
+- `docs/research_rsbs_stage2.md`: theory, benchmark findings, limitations, and literature boundary.
+- `docs/rsbs_confirmatory_protocol.md`: pre-specified Stage 3 benchmark protocol.
+
+## Recommended API use
+
+```python
+from survarena.methods.deep.rsbs_loss import hazard_from_logits, rsbs_loss
+
+hazard = hazard_from_logits(network(features))
+loss = rsbs_loss(
+    hazard,
+    exposure,
+    events,
+    reference_hazard,
+    beta=2.0,
+    eta=0.1,
+)
+```
+
+The reference hazard must be training-only and detached from the optimized network. `beta` and `eta` must be selected inside validation folds.
+
+## Status
+
+Exploratory. No universal performance claim is made. The confirmatory benchmark must use matched nested tuning, paired outer folds, censoring-support diagnostics, and corrected uncertainty intervals.

--- a/research/rsbs_stage2/RESULTS_POINTER.md
+++ b/research/rsbs_stage2/RESULTS_POINTER.md
@@ -1,0 +1,1 @@
+The full executed Stage 2 benchmark, figures, notebooks, and split-level CSVs are retained in the accompanying research bundle. This branch contains the reusable implementation and protocol rather than generated benchmark artifacts.

--- a/research/rsbs_stage2/STATUS.md
+++ b/research/rsbs_stage2/STATUS.md
@@ -1,0 +1,1 @@
+Exploratory branch. The drop-in loss, concordance references, mathematical tests, findings, and confirmatory protocol are ready for review. No universal performance claim is made.

--- a/survarena/evaluation/concordance_time_dependent.py
+++ b/survarena/evaluation/concordance_time_dependent.py
@@ -1,0 +1,108 @@
+"""Transparent concordance estimators for static and time-varying survival predictions."""
+from __future__ import annotations
+from typing import Optional
+import numpy as np
+
+
+def _at_time(survival: np.ndarray, grid: np.ndarray, time: float) -> np.ndarray:
+    index = int(np.clip(np.searchsorted(grid, time, side="right") - 1, 0, len(grid) - 1))
+    return survival[:, index]
+
+
+def harrell_c_index(time, event, risk, *, tau: Optional[float] = None) -> float:
+    """Observed comparable-pair concordance for a static risk score."""
+    time, event, risk = np.asarray(time, float), np.asarray(event, bool), np.asarray(risk, float)
+    numerator = denominator = 0.0
+    for i in np.flatnonzero(event):
+        if tau is not None and time[i] > tau:
+            continue
+        js = np.flatnonzero(time > time[i])
+        if not js.size:
+            continue
+        numerator += np.sum(risk[i] > risk[js]) + 0.5 * np.sum(np.isclose(risk[i], risk[js]))
+        denominator += js.size
+    return float(numerator / denominator) if denominator else float("nan")
+
+
+def antolini_c_index(time, event, survival, grid, *, tau: Optional[float] = None) -> float:
+    """Antolini concordance, comparing survival curves at the earlier event time."""
+    time, event = np.asarray(time, float), np.asarray(event, bool)
+    survival, grid = np.asarray(survival, float), np.asarray(grid, float)
+    numerator = denominator = 0.0
+    for i in np.flatnonzero(event):
+        if tau is not None and time[i] > tau:
+            continue
+        js = np.flatnonzero(time > time[i])
+        if not js.size:
+            continue
+        values = _at_time(survival, grid, time[i])
+        numerator += np.sum(values[i] < values[js]) + 0.5 * np.sum(np.isclose(values[i], values[js]))
+        denominator += js.size
+    return float(numerator / denominator) if denominator else float("nan")
+
+
+def time_dependent_uno_c_index(
+    time,
+    event,
+    survival,
+    grid,
+    *,
+    censor_survival,
+    tau: Optional[float] = None,
+) -> float:
+    """Marginal-IPCW dynamic concordance for subject-specific survival curves.
+
+    ``censor_survival[i]`` estimates G(T_i-) from training data. Event-subject
+    weights are 1/G(T_i-)^2.
+    """
+    time, event = np.asarray(time, float), np.asarray(event, bool)
+    survival, grid = np.asarray(survival, float), np.asarray(grid, float)
+    censor_survival = np.clip(np.asarray(censor_survival, float), 1e-6, 1.0)
+    numerator = denominator = 0.0
+    for i in np.flatnonzero(event):
+        if tau is not None and time[i] > tau:
+            continue
+        js = np.flatnonzero(time > time[i])
+        if not js.size:
+            continue
+        values = _at_time(survival, grid, time[i])
+        weight = 1.0 / censor_survival[i] ** 2
+        numerator += weight * (
+            np.sum(values[i] < values[js]) + 0.5 * np.sum(np.isclose(values[i], values[js]))
+        )
+        denominator += weight * js.size
+    return float(numerator / denominator) if denominator else float("nan")
+
+
+def conditional_time_dependent_uno_c_index(
+    time,
+    event,
+    survival,
+    grid,
+    *,
+    conditional_censor_survival,
+    tau: Optional[float] = None,
+) -> float:
+    """Pairwise conditional-IPCW dynamic concordance.
+
+    Matrix entry [i,j] estimates G(T_i- | X_j). Pair weight is
+    1/[G(T_i-|X_i)G(T_i-|X_j)]. Cross-fit the censoring model.
+    """
+    time, event = np.asarray(time, float), np.asarray(event, bool)
+    survival, grid = np.asarray(survival, float), np.asarray(grid, float)
+    conditional = np.clip(np.asarray(conditional_censor_survival, float), 1e-6, 1.0)
+    if conditional.shape != (len(time), len(time)):
+        raise ValueError("conditional_censor_survival must have shape [subjects, subjects]")
+    numerator = denominator = 0.0
+    for i in np.flatnonzero(event):
+        if tau is not None and time[i] > tau:
+            continue
+        js = np.flatnonzero(time > time[i])
+        if not js.size:
+            continue
+        values = _at_time(survival, grid, time[i])
+        weights = 1.0 / (conditional[i, i] * conditional[i, js])
+        comparisons = (values[i] < values[js]).astype(float) + 0.5 * np.isclose(values[i], values[js])
+        numerator += float(np.sum(weights * comparisons))
+        denominator += float(np.sum(weights))
+    return float(numerator / denominator) if denominator else float("nan")

--- a/survarena/methods/deep/rsbs_loss.py
+++ b/survarena/methods/deep/rsbs_loss.py
@@ -1,0 +1,146 @@
+"""Reference-Scaled Bregman Survival (RSBS) losses.
+
+Architecture-agnostic PyTorch losses for networks that output a positive
+piecewise-constant hazard. The reference intensity must be training-only and
+fixed with respect to the optimized network parameters.
+"""
+from __future__ import annotations
+
+from typing import Literal
+import torch
+from torch import Tensor
+
+Reduction = Literal["none", "mean", "sum"]
+
+
+def _reduce(per_subject: Tensor, reduction: Reduction) -> Tensor:
+    if reduction == "none":
+        return per_subject
+    if reduction == "mean":
+        return per_subject.mean()
+    if reduction == "sum":
+        return per_subject.sum()
+    raise ValueError(f"Unknown reduction: {reduction!r}")
+
+
+def _validate(hazard: Tensor, exposure: Tensor, events: Tensor, reference: Tensor) -> Tensor:
+    if hazard.shape != exposure.shape or hazard.shape != events.shape:
+        raise ValueError("hazard, exposure, and events must have identical shapes")
+    if hazard.ndim < 2:
+        raise ValueError("Expected [batch, time] tensors")
+    if torch.any(exposure < 0) or torch.any(events < 0):
+        raise ValueError("Exposure and events must be non-negative")
+    ref = torch.as_tensor(reference, dtype=hazard.dtype, device=hazard.device)
+    try:
+        return torch.broadcast_to(ref, hazard.shape)
+    except RuntimeError as exc:
+        raise ValueError("reference is not broadcastable to hazard") from exc
+
+
+def censored_log_intensity_score(
+    hazard: Tensor,
+    exposure: Tensor,
+    events: Tensor,
+    *,
+    eps: float = 1e-8,
+    reduction: Reduction = "mean",
+) -> Tensor:
+    """Piecewise-event-intensity negative log-likelihood."""
+    if hazard.shape != exposure.shape or hazard.shape != events.shape:
+        raise ValueError("hazard, exposure, and events must have identical shapes")
+    q = hazard.clamp_min(eps)
+    return _reduce((exposure * q - events * torch.log(q)).sum(dim=-1), reduction)
+
+
+def reference_scaled_bregman_score(
+    hazard: Tensor,
+    exposure: Tensor,
+    events: Tensor,
+    reference: Tensor,
+    *,
+    beta: float = 2.0,
+    eps: float = 1e-8,
+    reduction: Reduction = "mean",
+) -> Tensor:
+    r"""Reference-scaled beta-Bregman intensity score.
+
+    For beta != 1:
+
+      sum_k E_k a_k (q_k/a_k)^beta / beta
+          - D_k (q_k/a_k)^(beta-1)/(beta-1).
+
+    beta=1 is the logarithmic score up to a candidate-independent constant.
+    beta=2 gives sum E q^2/(2a) - D q/a.
+    """
+    ref = _validate(hazard, exposure, events, reference).clamp_min(eps)
+    q = hazard.clamp_min(eps)
+    if abs(float(beta) - 1.0) < 1e-8:
+        per_subject = (exposure * q - events * torch.log(q / ref)).sum(dim=-1)
+        return _reduce(per_subject, reduction)
+    if beta <= 0:
+        raise ValueError("beta must be positive")
+    ratio = q / ref
+    score = exposure * ref * ratio.pow(beta) / beta
+    score = score - events * ratio.pow(beta - 1.0) / (beta - 1.0)
+    return _reduce(score.sum(dim=-1), reduction)
+
+
+def rsbs_loss(
+    hazard: Tensor,
+    exposure: Tensor,
+    events: Tensor,
+    reference: Tensor,
+    *,
+    eta: float = 0.1,
+    beta: float = 2.0,
+    eps: float = 1e-8,
+    reduction: Reduction = "mean",
+) -> Tensor:
+    r"""Likelihood-anchored RSBS loss.
+
+      L_RSBS = L_log + eta L_beta,a, eta >= 0.
+
+    A non-negative mixture with the strictly proper log-intensity score remains
+    strictly proper on the observable support. The reference is detached
+    defensively; estimate it from training data or by cross-fitting.
+    """
+    if eta < 0:
+        raise ValueError("eta must be non-negative")
+    ref = torch.as_tensor(reference, dtype=hazard.dtype, device=hazard.device).detach()
+    log_part = censored_log_intensity_score(hazard, exposure, events, eps=eps, reduction="none")
+    beta_part = reference_scaled_bregman_score(
+        hazard, exposure, events, ref, beta=beta, eps=eps, reduction="none"
+    )
+    return _reduce(log_part + float(eta) * beta_part, reduction)
+
+
+def hazard_from_logits(logits: Tensor, *, link: Literal["softplus", "exp"] = "softplus") -> Tensor:
+    """Map unconstrained network outputs to positive hazards."""
+    if link == "softplus":
+        return torch.nn.functional.softplus(logits) + torch.finfo(logits.dtype).eps
+    if link == "exp":
+        return torch.exp(logits)
+    raise ValueError(f"Unknown link: {link!r}")
+
+
+def kmd_u_statistic(moment_residuals: Tensor) -> Tensor:
+    r"""Unbiased off-diagonal estimate of 0.5 ||E[xi]||^2.
+
+    This can be negative in finite samples. It is primarily a held-out model
+    specification diagnostic until its covariance and scale are stabilized.
+    """
+    if moment_residuals.ndim < 2 or moment_residuals.shape[0] < 2:
+        raise ValueError("Expected at least two subjects and one moment dimension")
+    flat = moment_residuals.reshape(moment_residuals.shape[0], -1)
+    n = flat.shape[0]
+    total = flat.sum(dim=0)
+    return 0.5 * (total.square().sum() - flat.square().sum()) / (n * (n - 1))
+
+
+__all__ = [
+    "censored_log_intensity_score",
+    "reference_scaled_bregman_score",
+    "rsbs_loss",
+    "hazard_from_logits",
+    "kmd_u_statistic",
+]

--- a/tests/test_rsbs_research.py
+++ b/tests/test_rsbs_research.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+
+from survarena.evaluation.concordance_time_dependent import (
+    antolini_c_index,
+    harrell_c_index,
+    time_dependent_uno_c_index,
+)
+from survarena.methods.deep.rsbs_loss import (
+    censored_log_intensity_score,
+    kmd_u_statistic,
+    reference_scaled_bregman_score,
+    rsbs_loss,
+)
+
+
+def test_beta_one_matches_log_score_up_to_reference_constant() -> None:
+    q = torch.tensor([[0.2, 0.6], [0.5, 0.9]], dtype=torch.float64)
+    e = torch.tensor([[1.0, 0.4], [1.0, 0.8]], dtype=torch.float64)
+    d = torch.tensor([[0.0, 1.0], [0.0, 0.0]], dtype=torch.float64)
+    a = torch.tensor([0.3, 0.7], dtype=torch.float64)
+    log_score = censored_log_intensity_score(q, e, d, reduction="none")
+    beta_one = reference_scaled_bregman_score(q, e, d, a, beta=1, reduction="none")
+    constant = (d * torch.log(a.expand_as(q))).sum(dim=-1)
+    torch.testing.assert_close(beta_one, log_score + constant)
+
+
+def test_reference_scaled_score_is_time_unit_invariant() -> None:
+    q = torch.tensor([[0.2, 0.4]], dtype=torch.float64)
+    e = torch.tensor([[3.0, 2.0]], dtype=torch.float64)
+    d = torch.tensor([[0.0, 1.0]], dtype=torch.float64)
+    a = torch.tensor([0.3, 0.5], dtype=torch.float64)
+    scale = 365.25
+    original = reference_scaled_bregman_score(q, e, d, a, beta=1.5)
+    transformed = reference_scaled_bregman_score(q / scale, e * scale, d, a / scale, beta=1.5)
+    torch.testing.assert_close(original, transformed, rtol=1e-12, atol=1e-12)
+
+
+def test_expected_quadratic_score_minimized_at_truth() -> None:
+    truth = 0.7
+    candidates = torch.linspace(0.05, 1.4, 200, dtype=torch.float64)
+    losses = torch.stack([
+        reference_scaled_bregman_score(
+            candidate.reshape(1, 1),
+            torch.ones((1, 1), dtype=torch.float64),
+            torch.tensor([[truth]], dtype=torch.float64),
+            torch.tensor([0.5], dtype=torch.float64),
+            beta=2,
+        )
+        for candidate in candidates
+    ])
+    assert float(candidates[int(torch.argmin(losses))]) == pytest.approx(truth, abs=0.01)
+
+
+def test_rsbs_detaches_reference_and_u_statistic_removes_diagonal() -> None:
+    q = torch.tensor([[0.4]], requires_grad=True)
+    a = torch.tensor([0.3], requires_grad=True)
+    rsbs_loss(q, torch.tensor([[1.0]]), torch.tensor([[1.0]]), a, eta=0.2).backward()
+    assert q.grad is not None and a.grad is None
+    assert float(kmd_u_statistic(torch.tensor([[1.0, 0.0], [-1.0, 0.0]]))) == pytest.approx(-0.5)
+
+
+def test_concordance_reference_cases() -> None:
+    time = np.array([1.0, 2.0, 3.0])
+    event = np.array([1, 1, 0], dtype=bool)
+    risk = np.array([3.0, 2.0, 1.0])
+    grid = np.array([0.0, 1.0, 2.0, 3.0])
+    survival = np.array([[1.0, 0.5, 0.3, 0.2], [1.0, 0.8, 0.6, 0.4], [1.0, 0.9, 0.8, 0.7]])
+    assert harrell_c_index(time, event, risk) == 1.0
+    assert antolini_c_index(time, event, survival, grid) == 1.0
+    assert time_dependent_uno_c_index(
+        time, event, survival, grid, censor_survival=np.ones(3)
+    ) == 1.0


### PR DESCRIPTION
## Summary

This draft research PR converts the Stage 2 survival-modeling study into reusable SurvArena components.

- adds an architecture-agnostic Reference-Scaled Bregman Survival (RSBS) PyTorch loss;
- adds transparent Harrell, Antolini, marginal time-dependent Uno, and conditional pairwise IPCW concordance references;
- adds mathematical unit tests for properness identities, time-unit invariance, reference detachment, and concordance behavior;
- documents the exploratory findings and a pre-specified confirmatory benchmark protocol.

## Scientific correction

The expanded benchmark does not support replacing likelihood with KMD. The observed crossing-hazard gains were primarily due to the time-varying hazard representation. The tested KMD training terms were too small to influence optimization. This PR therefore treats RSBS as the training direction and KMD as a held-out, cross-fitted specification diagnostic.

## Validation

The accompanying local research bundle contains 525 matched model fits across public and simulated data, 800 censoring-metric simulations, split-level outputs, 95% intervals, figures, and an executed notebook. Local mathematical tests passed.

## Status

Draft and exploratory. No universal performance claim is made; the confirmatory protocol requires repeated nested CV, equal tuning budgets, censoring-support diagnostics, and paired uncertainty intervals.